### PR TITLE
fix(tests): stop the local suite spending credit, and make it tell the truth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ tests/integration/cassettes
 tests/e2e/cassettes
 tests/e2e/audio_helper_outputs
 tests/benchmarks/vcr_cassettes
+tests/benchmarks/vcr_benchmark_report.txt
 tests/profiling/.baselines.json
 test_output
 examples/results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`adaptive-rate-limiter` now requires `>=1.3.0`** (was `>=1.1.0`). Venice meters requests
+  but not tokens, and the limiter could not represent that. Two layers had to change for the
+  adaptive path to work against this API at all.
+
+  The header gate in INTELLIGENT mode scored all six `x-ratelimit-*` headers as one pool and
+  demanded all six before syncing anything. Venice sends three, so every response fell through
+  to release-only: the backend was never called, the bucket was never verified, and the limiter
+  ran on fabricated cold-start limits for the life of the process. It failed silently — the
+  release path returns success and logs at debug, so nothing ever surfaced. Measured on a live
+  model: 427 cold-start probes across 66 minutes with the bucket never once written. The gate
+  is now assessed per dimension, so a request-only provider syncs the dimension it reports.
+
+  Underneath that, reset headers could not be parsed. Venice sends both reset stamps as absolute
+  epoch milliseconds; the library rewrote its own clean integer through `str(float(...))`, then
+  failed to parse the result, substituted `0`, and had its Lua reject the update on a post-2020
+  sanity floor. Absent counts were separately defaulted — remaining to `0`, limit to a fabricated
+  fallback — a pairing no server reports. Absent and genuinely-zero values are now distinguished,
+  and an incomplete dimension is skipped rather than sinking the whole update.
+
+  `1.2.x` is excluded deliberately rather than incidentally: `1.2.0` clamps an out-of-range token
+  window into range, which rotates it early and refills the token count before the server does,
+  and `1.2.1` still cannot get past the header gate on this API.
+
 - The README now carries a short note explaining that the package installs as `venice-py`,
   that imports and `VENICE_API_KEY` are unchanged, and that the `venice-ai` bridge declares
   no extras — so `venice-ai[cli]` and friends need the name updated.
@@ -20,6 +43,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   step of the distribution rename, and it changes nothing about what gets built or installed.
 
 ### Fixed
+
+- **Local test runs no longer record cassettes — and no longer spend API credit — by
+  default.** The VCR record mode defaulted to `NEW_EPISODES` outside CI, which replays what
+  a cassette holds and sends anything it lacks to the live Venice API. Cassettes are
+  gitignored, so a fresh clone has none and the first `make test` billed whoever's
+  `VENICE_API_KEY` was configured, silently. Recording is now opt-in through the existing
+  `VENICE_VCR_RECORD` variable (`all` re-records, `new` fills gaps); anything else replays
+  only, and a request with no cassette raises instead of reaching the network.
+  `make test-fresh` and `make test-quick` delete cassettes in order to re-record, so they
+  now pass the opt-in themselves and announce that they spend credit.
+
+- **Every VCR call site now resolves its record mode from one place**
+  (`tests/vcr_policy.py`). The benchmark suite built its own module-level `vcr.VCR` with a
+  hardcoded `RecordMode.ONCE`, under a module global that shadowed the `vcr_config` fixture
+  name. `VENICE_CI_MODE=true` is only read inside that fixture, so the documented guarantee
+  that CI never records did not hold for that module, and it recorded whenever a cassette
+  was absent.
+
+- **Benchmark tests now look for their cassettes where they actually live.** The cassette
+  directory was chosen by test path, special-casing only `tests/e2e/`, so tests under
+  `tests/benchmarks/` resolved to `tests/integration/cassettes` and could never match a
+  cassette — every request either went live or failed outright. Both fixtures that made
+  this choice now share one helper.
+
+- **The adaptive rate-limiter saturation benchmark now enforces its own pass criterion.**
+  It computed whether the contended p50 stayed within 50% of the control p50, wrote that
+  verdict into a report, and returned without asserting it, so the test could not fail on
+  the property it exists to measure. It now asserts the criterion — and asserts that
+  latency samples were collected at all, since an empty sample set drove the computed delta
+  to zero and produced a pass.
 
 - **`__version__` no longer falls back to a plausible-looking version string.** When the
   package metadata cannot be read — a source tree with nothing installed — `__version__`

--- a/Makefile
+++ b/Makefile
@@ -99,12 +99,14 @@ test-refresh: clean ## Refresh model cache from API and run tests
 	@echo "$(GREEN)Refreshing model cache and running tests...$(NC)"
 	$(PYTEST) tests/ --refresh-models --no-cov $(PYTEST_COMMON) $(PYTEST_IGNORE) -q $(ARGS)
 
-test-fresh: clean-cassettes test ## Delete cassettes and run tests (regenerate VCR)
+test-fresh: clean-cassettes ## Delete cassettes and re-record them live (SPENDS CREDIT)
+	@echo "$(YELLOW)Re-recording every cassette against the live API — this spends credit.$(NC)"
+	VENICE_VCR_RECORD=all $(MAKE) test
 	@echo "$(GREEN)Tests completed with fresh cassettes!$(NC)"
 
-test-quick: clean-cassettes ## Fast iteration: E2E + modified integration tests
-	@echo "$(GREEN)Running quick test iteration...$(NC)"
-	$(PYTEST) tests/e2e/ \
+test-quick: clean-cassettes ## Fast iteration: E2E + modified integration tests (SPENDS CREDIT)
+	@echo "$(YELLOW)Re-recording the selected cassettes against the live API — spends credit.$(NC)"
+	VENICE_VCR_RECORD=all $(PYTEST) tests/e2e/ \
 		tests/integration/test_image_vcr.py \
 		tests/integration/test_api_keys_vcr.py \
 		tests/integration/test_embeddings_vcr.py \
@@ -310,7 +312,7 @@ clean: ## Clean test artifacts and cache
 	@find . -type f -name "*.pyc" -delete 2>/dev/null || true
 	@find . -type f -name ".DS_Store" -delete 2>/dev/null || true
 
-clean-cassettes: ## Delete all VCR cassettes (force live API testing)
+clean-cassettes: ## Delete all VCR cassettes (re-record needs VENICE_VCR_RECORD=all)
 	@echo "$(YELLOW)Deleting all VCR cassettes...$(NC)"
 	@find tests -type d -name "cassettes" -exec rm -rf {} + 2>/dev/null || true
 	@echo "$(GREEN)All VCR cassettes deleted$(NC)"

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,7 +7,7 @@ description = "Parsers for ABNF grammars."
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "abnf-2.6.0-py3-none-any.whl", hash = "sha256:e40aed8e105846ba91a566f6e0f6878cc6cae61218bc949ca05b3577bed92c6e"},
     {file = "abnf-2.6.0.tar.gz", hash = "sha256:945c1377ef6dfc25ae19fd6d6eafe767e6cf8d3a9cbd3e4cd9ef715607ee2068"},
@@ -20,16 +20,16 @@ rust = ["abnf-rust (>=2.5,<3)"]
 
 [[package]]
 name = "adaptive-rate-limiter"
-version = "1.1.0"
+version = "1.3.0"
 description = "Adaptive rate limiting for API clients with multi-provider support"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "adaptive_rate_limiter-1.1.0-py3-none-any.whl", hash = "sha256:d2c6c4c0fb8eae45be1abe5d1341b08cccdfd801237073b3d07cd222f0f447c9"},
-    {file = "adaptive_rate_limiter-1.1.0.tar.gz", hash = "sha256:52ba723cab0e76436b1d7c231e0259fe29252a0ee9db63c5352eec96516599b8"},
+    {file = "adaptive_rate_limiter-1.3.0-py3-none-any.whl", hash = "sha256:1e7f645e41d29d290ef78c3e1b05b09748fb3dcbe9d4cb279778b1036c1051ee"},
+    {file = "adaptive_rate_limiter-1.3.0.tar.gz", hash = "sha256:2d4231ead24ae27918cbd05a0ffbf3e2aae36f74f2266fb479622cb236323c27"},
 ]
-markers = {main = "extra == \"adaptive\" or extra == \"all\" or extra == \"enterprise\""}
+markers = {main = "extra == \"adaptive\" or extra == \"enterprise\" or extra == \"all\""}
 
 [package.dependencies]
 pydantic = ">=2.0.0,<3.0.0"
@@ -67,7 +67,7 @@ files = [
     {file = "aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695"},
     {file = "aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2"},
 ]
-markers = {main = "extra == \"all\" or extra == \"cli\""}
+markers = {main = "extra == \"cli\" or extra == \"all\""}
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -520,7 +520,7 @@ description = "efficient arrays of booleans -- C extension"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "bitarray-3.10.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:fdcdb64d155ebddc2adca2d9eabf3ae93f3e2a1b244bee5a7cb36b75f16259cd"},
     {file = "bitarray-3.10.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b42adba4705a4e461ff3c76b89b1622a15c26759101226a66419adab60632035"},
@@ -870,7 +870,7 @@ files = [
     {file = "certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775"},
     {file = "certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55"},
 ]
-markers = {main = "extra == \"all\" or extra == \"x402\""}
+markers = {main = "extra == \"x402\" or extra == \"all\""}
 
 [[package]]
 name = "cffi"
@@ -879,7 +879,7 @@ description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "sys_platform != \"android\" and sys_platform != \"ios\" or platform_python_implementation != \"CPython\" or extra == \"all\" or extra == \"e2ee\" or extra == \"e2ee-verify\""
+markers = "sys_platform != \"android\" and sys_platform != \"ios\" or platform_python_implementation != \"CPython\" or extra == \"e2ee\" or extra == \"e2ee-verify\" or extra == \"all\""
 files = [
     {file = "cffi-2.1.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:baed1e86cc735622097354b9d1281406caf42ff42a886d29faa8e8d1630333be"},
     {file = "cffi-2.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ca82be1a1d406ecfe1d25dc16cb33488e5a16bf4438c9fb590484ea29d92478b"},
@@ -1100,7 +1100,7 @@ files = [
     {file = "charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5"},
     {file = "charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b"},
 ]
-markers = {main = "extra == \"all\" or extra == \"x402\""}
+markers = {main = "extra == \"x402\" or extra == \"all\""}
 
 [[package]]
 name = "ckzg"
@@ -1109,7 +1109,7 @@ description = "Python bindings for C-KZG-4844"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "ckzg-2.1.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8dc23b189b5e061b5a2fcf609b6dc1f62098dd72cf9116e4721f995eb144b0ee"},
     {file = "ckzg-2.1.8-cp310-cp310-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:71e0e6d84a268c23c29d546a7ef4720a9d2aea597efe4def75205b6ef436900c"},
@@ -1181,7 +1181,7 @@ files = [
     {file = "click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"},
     {file = "click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6"},
 ]
-markers = {main = "extra == \"all\" or extra == \"cli\""}
+markers = {main = "extra == \"cli\" or extra == \"all\""}
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
@@ -1197,7 +1197,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\" and (extra == \"all\" or extra == \"cli\")", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
+markers = {main = "platform_system == \"Windows\" and (extra == \"cli\" or extra == \"all\")", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
 
 [[package]]
 name = "coverage"
@@ -1340,7 +1340,7 @@ description = "cryptography is a package which provides cryptographic recipes an
 optional = true
 python-versions = "!=3.9.0,!=3.9.1,>=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"e2ee\" or extra == \"e2ee-verify\""
+markers = "extra == \"e2ee\" or extra == \"e2ee-verify\" or extra == \"all\""
 files = [
     {file = "cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03"},
     {file = "cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645"},
@@ -1448,7 +1448,7 @@ description = "Cython implementation of Toolz: High performance functional utili
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "implementation_name == \"cpython\" and (extra == \"all\" or extra == \"x402\")"
+markers = "implementation_name == \"cpython\" and (extra == \"x402\" or extra == \"all\")"
 files = [
     {file = "cytoolz-1.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:72d7043a88ea5e61ba9d17ea0d1c1eff10f645d7edfcc4e56a31ef78be287644"},
     {file = "cytoolz-1.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d759e9ed421bacfeb456d47af8d734c057b9912b5f2441f95b27ca35e5efab07"},
@@ -1639,7 +1639,7 @@ description = "Python bindings for DCAP (Data Center Attestation Primitives) quo
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"e2ee-verify\""
+markers = "extra == \"e2ee-verify\" or extra == \"all\""
 files = [
     {file = "dcap_qvl-0.6.1-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:fc64c271a41413b44dd9185c8ceff7d48033b8708047cc89e9899f0442003d4a"},
     {file = "dcap_qvl-0.6.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:b09b5c20f17bcb44b3ed65d873b0d055f241aff5549d0d098637608892261c6e"},
@@ -1670,7 +1670,7 @@ description = "eth_abi: Python utilities for working with Ethereum ABI definitio
 optional = true
 python-versions = "<4,>=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "eth_abi-5.2.0-py3-none-any.whl", hash = "sha256:17abe47560ad753f18054f5b3089fcb588f3e3a092136a416b6c1502cb7e8877"},
     {file = "eth_abi-5.2.0.tar.gz", hash = "sha256:178703fa98c07d8eecd5ae569e7e8d159e493ebb6eeb534a8fe973fbc4e40ef0"},
@@ -1694,7 +1694,7 @@ description = "eth-account: Sign Ethereum transactions and messages with local p
 optional = true
 python-versions = "<4,>=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "eth_account-0.13.7-py3-none-any.whl", hash = "sha256:39727de8c94d004ff61d10da7587509c04d2dc7eac71e04830135300bdfc6d24"},
     {file = "eth_account-0.13.7.tar.gz", hash = "sha256:5853ecbcbb22e65411176f121f5f24b8afeeaf13492359d254b16d8b18c77a46"},
@@ -1724,7 +1724,7 @@ description = "eth-hash: The Ethereum hashing function, keccak256, sometimes (er
 optional = true
 python-versions = "<4,>=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "eth_hash-0.8.0-py3-none-any.whl", hash = "sha256:523718a51b369ab89866b929a5c93c52978cd866ea309192ad980dd8271f9fac"},
     {file = "eth_hash-0.8.0.tar.gz", hash = "sha256:b009752b620da2e9c7668014849d1f5fadbe4f138603f1871cc5d4ca706896b1"},
@@ -1747,7 +1747,7 @@ description = "eth-keyfile: A library for handling the encrypted keyfiles used t
 optional = true
 python-versions = "<4,>=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "eth_keyfile-0.8.1-py3-none-any.whl", hash = "sha256:65387378b82fe7e86d7cb9f8d98e6d639142661b2f6f490629da09fddbef6d64"},
     {file = "eth_keyfile-0.8.1.tar.gz", hash = "sha256:9708bc31f386b52cca0969238ff35b1ac72bd7a7186f2a84b86110d3c973bec1"},
@@ -1770,7 +1770,7 @@ description = "eth-keys: Common API for Ethereum key operations"
 optional = true
 python-versions = "<4,>=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "eth_keys-0.7.0-py3-none-any.whl", hash = "sha256:b0cdda8ffe8e5ba69c7c5ca33f153828edcace844f67aabd4542d7de38b159cf"},
     {file = "eth_keys-0.7.0.tar.gz", hash = "sha256:79d24fd876201df67741de3e3fefb3f4dbcbb6ace66e47e6fe662851a4547814"},
@@ -1793,7 +1793,7 @@ description = "eth-rlp: RLP definitions for common Ethereum objects in Python"
 optional = true
 python-versions = "<4,>=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "eth_rlp-2.2.0-py3-none-any.whl", hash = "sha256:5692d595a741fbaef1203db6a2fedffbd2506d31455a6ad378c8449ee5985c47"},
     {file = "eth_rlp-2.2.0.tar.gz", hash = "sha256:5e4b2eb1b8213e303d6a232dfe35ab8c29e2d3051b86e8d359def80cd21db83d"},
@@ -1816,7 +1816,7 @@ description = "eth-typing: Common type annotations for ethereum python packages"
 optional = true
 python-versions = "<4,>=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "eth_typing-6.0.0-py3-none-any.whl", hash = "sha256:ee74fb641eb36dd885e1c42c2a3055314efa532b3e71480816df70a94d35cfb9"},
     {file = "eth_typing-6.0.0.tar.gz", hash = "sha256:315dd460dc0b71c15a6cd51e3c0b70d237eec8771beb844144f3a1fb4adb2392"},
@@ -1837,7 +1837,7 @@ description = "eth-utils: Common utility functions for python code that interact
 optional = true
 python-versions = "<4,>=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "eth_utils-6.0.0-py3-none-any.whl", hash = "sha256:63cf48ee32c45541cb5748751909a8345c470432fb6f0fed4bd7c53fd6400469"},
     {file = "eth_utils-6.0.0.tar.gz", hash = "sha256:eb54b2f82dd300d3142c49a89da195e823f5e5284d43203593f87c67bad92a96"},
@@ -1881,7 +1881,7 @@ files = [
     {file = "filelock-3.32.3-py3-none-any.whl", hash = "sha256:7f0ca4bcc0e181c60dbbd8aa9ab5b120ebb99e4e064e83636340056f833a1f09"},
     {file = "filelock-3.32.3.tar.gz", hash = "sha256:0ffa185a3540854c95caa7fa76b76cb219d907415e2c5dc9af25fd970563487f"},
 ]
-markers = {main = "extra == \"all\" or extra == \"cli\""}
+markers = {main = "extra == \"cli\" or extra == \"all\""}
 
 [[package]]
 name = "fqdn"
@@ -2057,7 +2057,7 @@ description = "hexbytes: Python `bytes` subclass that decodes hex, with a readab
 optional = true
 python-versions = "<4,>=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "hexbytes-1.3.1-py3-none-any.whl", hash = "sha256:da01ff24a1a9a2b1881c4b85f0e9f9b0f51b526b379ffa23832ae7899d29c2c7"},
     {file = "hexbytes-1.3.1.tar.gz", hash = "sha256:a657eebebdfe27254336f98d8af6e2236f3f83aed164b87466b6cf6c5f5a4765"},
@@ -2231,7 +2231,7 @@ description = "A microlibrary that defines a Json type alias for Python."
 optional = true
 python-versions = ">=3.7,<4.0"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402-solana\""
+markers = "extra == \"x402-solana\" or extra == \"all\""
 files = [
     {file = "jsonalias-0.1.1-py3-none-any.whl", hash = "sha256:a56d2888e6397812c606156504e861e8ec00e188005af149f003c787db3d3f18"},
     {file = "jsonalias-0.1.1.tar.gz", hash = "sha256:64f04d935397d579fc94509e1fcb6212f2d081235d9d6395bd10baedf760a769"},
@@ -2739,7 +2739,7 @@ files = [
     {file = "markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a"},
     {file = "markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49"},
 ]
-markers = {main = "extra == \"all\" or extra == \"cli\""}
+markers = {main = "extra == \"cli\" or extra == \"all\""}
 
 [package.dependencies]
 linkify-it-py = {version = ">=1,<3", optional = true, markers = "extra == \"linkify\""}
@@ -2884,7 +2884,7 @@ files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
-markers = {main = "extra == \"all\" or extra == \"cli\""}
+markers = {main = "extra == \"cli\" or extra == \"all\""}
 
 [[package]]
 name = "msgpack"
@@ -3341,7 +3341,7 @@ description = "OpenTelemetry Python API"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"enterprise\" or extra == \"observability\""
+markers = "extra == \"observability\" or extra == \"enterprise\" or extra == \"all\""
 files = [
     {file = "opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef"},
     {file = "opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a"},
@@ -3357,7 +3357,7 @@ description = "OpenTelemetry Python SDK"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"enterprise\" or extra == \"observability\""
+markers = "extra == \"observability\" or extra == \"enterprise\" or extra == \"all\""
 files = [
     {file = "opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad"},
     {file = "opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b"},
@@ -3378,7 +3378,7 @@ description = "OpenTelemetry Semantic Conventions"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"enterprise\" or extra == \"observability\""
+markers = "extra == \"observability\" or extra == \"enterprise\" or extra == \"all\""
 files = [
     {file = "opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb"},
     {file = "opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60"},
@@ -3425,7 +3425,7 @@ description = "(Soon to be) the fastest pure-Python PEG parser I could muster"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "parsimonious-0.10.0-py3-none-any.whl", hash = "sha256:982ab435fabe86519b57f6b35610aa4e4e977e9f02a14353edf4bbc75369fc0f"},
     {file = "parsimonious-0.10.0.tar.gz", hash = "sha256:8281600da180ec8ae35427a4ab4f7b82bfec1e3d1e52f80cb60ea82b9512501c"},
@@ -3547,7 +3547,7 @@ files = [
     {file = "pillow-12.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:04f01d28a6aaff387bf842a13be313df23ba0597a44f1a976c9feb3c6ff4711a"},
     {file = "pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce"},
 ]
-markers = {main = "extra == \"all\" or extra == \"cli\""}
+markers = {main = "extra == \"cli\" or extra == \"all\""}
 
 [package.extras]
 docs = ["furo", "olefile", "sphinx (>=8.2)", "sphinx-autobuild", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxext-opengraph"]
@@ -3674,7 +3674,7 @@ files = [
     {file = "prometheus_client-0.26.0-py3-none-any.whl", hash = "sha256:fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6"},
     {file = "prometheus_client-0.26.0.tar.gz", hash = "sha256:04a91bcf94e2cf74a44a1a874d651a2e853ed354b6e822f3b7487751465d5c2b"},
 ]
-markers = {main = "extra == \"all\" or extra == \"enterprise\" or extra == \"metrics\""}
+markers = {main = "extra == \"metrics\" or extra == \"enterprise\" or extra == \"all\""}
 
 [package.extras]
 aiohttp = ["aiohttp"]
@@ -3692,7 +3692,7 @@ files = [
     {file = "prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2"},
     {file = "prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6"},
 ]
-markers = {main = "extra == \"all\" or extra == \"cli\""}
+markers = {main = "extra == \"cli\" or extra == \"all\""}
 
 [package.dependencies]
 wcwidth = ">=0.1.4"
@@ -4011,7 +4011,7 @@ description = "C parser in Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "(sys_platform != \"android\" and sys_platform != \"ios\" or platform_python_implementation != \"CPython\" or extra == \"all\" or extra == \"e2ee\" or extra == \"e2ee-verify\") and implementation_name != \"PyPy\""
+markers = "(sys_platform != \"android\" and sys_platform != \"ios\" or platform_python_implementation != \"CPython\" or extra == \"e2ee\" or extra == \"e2ee-verify\" or extra == \"all\") and implementation_name != \"PyPy\""
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
@@ -4024,7 +4024,7 @@ description = "Cryptographic library for Python"
 optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "pycryptodome-3.23.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a176b79c49af27d7f6c12e4b178b0824626f40a7b9fed08f712291b6d54bf566"},
     {file = "pycryptodome-3.23.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:573a0b3017e06f2cffd27d92ef22e46aa3be87a2d317a5abf7cc0e84e321bd75"},
@@ -4231,7 +4231,7 @@ description = "Settings management using Pydantic"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"enterprise\""
+markers = "extra == \"enterprise\" or extra == \"all\""
 files = [
     {file = "pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42"},
     {file = "pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117"},
@@ -4272,7 +4272,7 @@ files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
-markers = {main = "extra == \"all\" or extra == \"cli\""}
+markers = {main = "extra == \"cli\" or extra == \"all\""}
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
@@ -4521,7 +4521,7 @@ files = [
     {file = "python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a"},
     {file = "python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3"},
 ]
-markers = {main = "extra == \"all\" or extra == \"enterprise\" or extra == \"cli\""}
+markers = {main = "extra == \"enterprise\" or extra == \"all\" or extra == \"cli\""}
 
 [package.extras]
 cli = ["click (>=5.0)"]
@@ -4588,7 +4588,7 @@ description = "A library for Unicode normalization (NFC, NFD, NFKC, NFKD) indepe
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "pyunormalize-17.0.0-py3-none-any.whl", hash = "sha256:f0d93b076f938db2b26d319d04f2b58505d1cd7a80b5b72badbe7d1aa4d2a31c"},
     {file = "pyunormalize-17.0.0.tar.gz", hash = "sha256:0949a3e56817e287febcaf1b0cc4b5adf0bb107628d379335938040947eec792"},
@@ -4601,7 +4601,7 @@ description = "Python for Windows Extensions"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "platform_system == \"Windows\" and (extra == \"all\" or extra == \"x402\")"
+markers = "platform_system == \"Windows\" and (extra == \"x402\" or extra == \"all\")"
 files = [
     {file = "pywin32-312-cp310-cp310-win32.whl", hash = "sha256:772235332b5d1024c696f11cea1ae4be7930f0a8b894bb43db14e3f435f1ff7e"},
     {file = "pywin32-312-cp310-cp310-win_amd64.whl", hash = "sha256:5dbc35d2b5320dc07f25fa31269cfb767471002b17de5eb067d03da68c7cb2db"},
@@ -4708,7 +4708,7 @@ files = [
     {file = "pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007"},
     {file = "pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"},
 ]
-markers = {main = "extra == \"all\" or extra == \"cli\""}
+markers = {main = "extra == \"cli\" or extra == \"all\""}
 
 [[package]]
 name = "pyyaml-ft"
@@ -4749,7 +4749,7 @@ files = [
     {file = "questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59"},
     {file = "questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d"},
 ]
-markers = {main = "extra == \"all\" or extra == \"cli\""}
+markers = {main = "extra == \"cli\" or extra == \"all\""}
 
 [package.dependencies]
 prompt_toolkit = ">=2.0,<4.0"
@@ -4761,7 +4761,7 @@ description = "Python client for Redis database and key-value store"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"adaptive\" or extra == \"all\" or extra == \"enterprise\" or extra == \"redis\""
+markers = "extra == \"redis\" or extra == \"adaptive\" or extra == \"enterprise\" or extra == \"all\""
 files = [
     {file = "redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb"},
     {file = "redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25"},
@@ -4914,7 +4914,7 @@ files = [
     {file = "regex-2026.7.19-cp314-cp314t-win_arm64.whl", hash = "sha256:9a15e785f244f3e07847b984ce8773fc3da10a9f3c131cc49a4c5b4d672b4547"},
     {file = "regex-2026.7.19.tar.gz", hash = "sha256:7e77b324909c1617cbb4c668677e2c6ae13f44d7c1de0d4f15f2e3c10f3315b5"},
 ]
-markers = {main = "extra == \"all\" or extra == \"x402\""}
+markers = {main = "extra == \"x402\" or extra == \"all\""}
 
 [[package]]
 name = "requests"
@@ -4927,7 +4927,7 @@ files = [
     {file = "requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"},
     {file = "requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"},
 ]
-markers = {main = "extra == \"all\" or extra == \"x402\""}
+markers = {main = "extra == \"x402\" or extra == \"all\""}
 
 [package.dependencies]
 certifi = ">=2023.5.7"
@@ -4995,7 +4995,7 @@ files = [
     {file = "rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"},
     {file = "rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"},
 ]
-markers = {main = "extra == \"all\" or extra == \"cli\""}
+markers = {main = "extra == \"cli\" or extra == \"all\""}
 
 [package.dependencies]
 markdown-it-py = ">=2.2.0"
@@ -5011,7 +5011,7 @@ description = "rlp: A package for Recursive Length Prefix encoding and decoding"
 optional = true
 python-versions = "<4,>=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "rlp-4.1.0-py3-none-any.whl", hash = "sha256:8eca394c579bad34ee0b937aecb96a57052ff3716e19c7a578883e767bc5da6f"},
     {file = "rlp-4.1.0.tar.gz", hash = "sha256:be07564270a96f3e225e2c107db263de96b5bc1f27722d2855bd3459a08e95a9"},
@@ -5318,7 +5318,7 @@ description = "A Python implementation of Sign-In with Ethereum (EIP-4361)."
 optional = true
 python-versions = "<4.0,>=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "siwe-4.4.0-py3-none-any.whl", hash = "sha256:3a4db2d36e10933c01d09ba0aad4db2f404e9ab2c9e9a204fa1bc1103e9d754d"},
     {file = "siwe-4.4.0.tar.gz", hash = "sha256:5fdf843253a91d78085f1da11ed7c9695bbb743e112da658e63a285ddf3ffec7"},
@@ -5368,7 +5368,7 @@ description = "Python bindings for Solana Rust tools"
 optional = true
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402-solana\""
+markers = "extra == \"x402-solana\" or extra == \"all\""
 files = [
     {file = "solders-0.29.0-cp310-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:785841623bdd7b8dedc68e7c794b54327d3b03e1ab9697eda90a139ca3c98cfe"},
     {file = "solders-0.29.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00524baf575ae5edb2ba43cdb1d80491c59efdc16b48fec96a6f929c0401d0e4"},
@@ -5631,7 +5631,7 @@ description = "List processing tools and functional utilities"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(implementation_name == \"pypy\" or implementation_name == \"cpython\") and (extra == \"all\" or extra == \"x402\")"
+markers = "(implementation_name == \"pypy\" or implementation_name == \"cpython\") and (extra == \"x402\" or extra == \"all\")"
 files = [
     {file = "toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8"},
     {file = "toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b"},
@@ -5664,7 +5664,7 @@ description = "Typing stubs for requests"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "types_requests-2.33.0.20260712-py3-none-any.whl", hash = "sha256:de027e28c171d3da529689cbfa023b0b4eab188c8dfa22fd834eebd2cee6e7bb"},
     {file = "types_requests-2.33.0.20260712.tar.gz", hash = "sha256:2141b67ab534a5c5cd2dac5034f2a35f42e699c5bf185eee608c5246a069d7fb"},
@@ -5753,7 +5753,7 @@ files = [
     {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
     {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
-markers = {main = "extra == \"all\" or extra == \"x402\""}
+markers = {main = "extra == \"x402\" or extra == \"all\""}
 
 [package.extras]
 brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
@@ -5804,7 +5804,7 @@ files = [
     {file = "wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85"},
     {file = "wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda"},
 ]
-markers = {main = "extra == \"all\" or extra == \"cli\""}
+markers = {main = "extra == \"cli\" or extra == \"all\""}
 
 [[package]]
 name = "web3"
@@ -5813,7 +5813,7 @@ description = "web3: A Python library for interacting with Ethereum"
 optional = true
 python-versions = "<4,>=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "web3-7.16.0-py3-none-any.whl", hash = "sha256:760b2718c473980d70708c3593d9d28395db4b482f45e38a63a36fa028178f51"},
     {file = "web3-7.16.0.tar.gz", hash = "sha256:b4a75a3fa94fef4d23d502eb3c2244146ef9a1ee0082cf1cb0a91586ba0510c3"},
@@ -5860,7 +5860,7 @@ description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"x402\""
+markers = "extra == \"x402\" or extra == \"all\""
 files = [
     {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b"},
     {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205"},
@@ -6171,4 +6171,4 @@ x402-solana = ["solders"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "a0f2560530df1da52820590f037434f74cb62bba8e53ff3f2806095c93dc7987"
+content-hash = "be726b6d80923bd975101935abd8bf98fd9b90139bb5bdcd4d2a2d313b4737d7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ filelock = { version = "^3.29.0", optional = true }
 Pillow = { version = "^12.2.0", optional = true } # For image processing (e.g., dimension checks)
 redis = { version = "^8.0.0", optional = true }
 pydantic-settings = { version = "^2.14.1", optional = true }
-adaptive-rate-limiter = { version = "^1.1.0", optional = true }
+adaptive-rate-limiter = { version = "^1.3.0", optional = true }
 opentelemetry-api = { version = "^1.41.0", optional = true } # For distributed tracing
 opentelemetry-sdk = { version = "^1.41.0", optional = true } # For distributed tracing
 # CLI dependencies (optional - install with pip install venice-py[cli])
@@ -140,7 +140,7 @@ Documentation = "https://venice-docs.sbang.dev"
 "Changelog" = "https://github.com/sethbang/venice-py/blob/main/CHANGELOG.md"
 
 [tool.poetry.group.dev.dependencies]
-adaptive-rate-limiter = "^1.1.0"
+adaptive-rate-limiter = "^1.3.0"
 pytest = "^9.0.3"
 pytest-timeout = "^2.4.0"
 pytest-cov = "^7.1.0"

--- a/tests/benchmarks/test_adaptive_saturation.py
+++ b/tests/benchmarks/test_adaptive_saturation.py
@@ -33,9 +33,15 @@ Why ``VeniceClientFactory`` instead of ``VeniceClient(rate_limiter=...)``?
   a ``RateLimiterConfig`` dataclass. The supported wiring path for
   ADAPTIVE mode is::
 
-    config = VeniceAIConfig(rate_limiter=RateLimiterConfig(
-        mode=RateLimiterMode.ADAPTIVE, redis_url=...,
-    ))
+    config = VeniceAIConfig(
+        rate_limiter=RateLimiterConfig(
+            mode=RateLimiterMode.ADAPTIVE, redis_url=...,
+        ),
+        backend=BackendConfig(
+            backend_type=BackendType.REDIS,
+            redis=RedisBackendConfig(redis_url=...),
+        ),
+    )
     client = VeniceClientFactory.create_client(config, api_key=...)
 
   which is what this benchmark uses.
@@ -54,6 +60,11 @@ import pytest
 
 from venice_ai import UserMessage
 from venice_ai.core.config import VeniceAIConfig
+from venice_ai.core.config.backends import (
+    BackendConfig,
+    BackendType,
+    RedisBackendConfig,
+)
 from venice_ai.factory import VeniceClientFactory
 from venice_ai.rate_limiting import RateLimiterConfig, RateLimiterMode
 from venice_ai.types.api.models import LLMModelPricing, TextModelSpec
@@ -353,6 +364,10 @@ def write_saturation_report(
         f"| `{choices['L'].id}` | `{choices['XS'].id}` | {ctl_p50:.0f} ms | "
         f"{cnt_p50:.0f} ms | {delta_pct:+.1f}% | {'YES' if iso_pass else 'NO'} |\n"
     )
+    # The audits directory is not tracked, so it may not exist on a fresh
+    # checkout. Create it rather than losing a completed live run — this
+    # write happens after every request has already been paid for.
+    RESULTS_PATH.parent.mkdir(parents=True, exist_ok=True)
     RESULTS_PATH.write_text(body, encoding="utf-8")
 
 
@@ -376,10 +391,18 @@ async def test_saturation_full_run() -> None:
     if not os.environ.get("VENICE_API_KEY"):
         pytest.skip("VENICE_API_KEY not set; live API calls are required.")
 
+    # backend_type must be set explicitly: it defaults to MEMORY, and a
+    # rate_limiter redis_url on its own does not change it. Without this the
+    # run silently uses the in-process backend and measures nothing about the
+    # cross-process coordination the adaptive limiter exists to provide.
     config = VeniceAIConfig(
         rate_limiter=RateLimiterConfig(
             mode=RateLimiterMode.ADAPTIVE,
             redis_url=redis_url,
+        ),
+        backend=BackendConfig(
+            backend_type=BackendType.REDIS,
+            redis=RedisBackendConfig(redis_url=redis_url),
         ),
     )
     client = VeniceClientFactory.create_client(config)
@@ -407,4 +430,18 @@ async def test_saturation_full_run() -> None:
 
     write_saturation_report(
         single_results, choices, ctl_p50, cnt_p50, delta_pct, isolation_pass, spent
+    )
+
+    # Asserted after the report is written so a failing run still leaves its
+    # diagnostics on disk.
+    #
+    # The emptiness checks are not incidental: with no control samples ctl_p50
+    # is 0.0, which pins delta_pct to 0.0 and makes isolation_pass true. A run
+    # that measured nothing has to fail rather than report success.
+    assert ctl, "isolation run collected no control latencies; nothing was measured"
+    assert cnt, "isolation run collected no contended latencies; nothing was measured"
+    assert isolation_pass, (
+        f"adaptive limiter did not isolate the light model from the heavy one: "
+        f"contended p50 {cnt_p50:.3f}s vs control p50 {ctl_p50:.3f}s "
+        f"({delta_pct:+.1f}%, criterion <50%)"
     )

--- a/tests/benchmarks/test_vcr_scheduler_benchmarks.py
+++ b/tests/benchmarks/test_vcr_scheduler_benchmarks.py
@@ -43,7 +43,6 @@ from typing import Any
 
 import pytest
 import vcr
-from vcr.record_mode import RecordMode
 
 from tests.benchmarks.metrics import BenchmarkResults, MetricsCollector
 from tests.benchmarks.reporters import BenchmarkReporter
@@ -51,6 +50,7 @@ from tests.benchmarks.scenarios import (
     BenchmarkScenario,
     RequestPattern,
 )
+from tests.vcr_policy import resolve_record_mode
 from venice_ai import VeniceAIConfig
 from venice_ai.core.config import (
     BackendConfig,
@@ -68,7 +68,10 @@ VCR_CASSETTE_DIR.mkdir(exist_ok=True)
 # Configure VCR for Venice API
 vcr_config = vcr.VCR(
     cassette_library_dir=str(VCR_CASSETTE_DIR),
-    record_mode=RecordMode.ONCE,  # Only record if cassette doesn't exist
+    # Resolved centrally. This instance shadows the root ``vcr_config`` fixture
+    # name, so a mode hardcoded here would bypass VENICE_CI_MODE entirely and
+    # record — and therefore bill — whenever a cassette is absent.
+    record_mode=resolve_record_mode(),
     match_on=["method", "uri", "body"],
     filter_headers=["Authorization", "X-API-Key"],  # Hide sensitive data
     decode_compressed_response=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,8 @@ import vcr
 from aiohttp import ClientSession
 from vcr.record_mode import RecordMode
 
+from tests.vcr_policy import cassette_dir_for, resolve_record_mode
+
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
@@ -981,7 +983,9 @@ def vcr_config():
     - Records HTTP interactions to YAML cassettes
     - Scrubs Authorization headers to prevent API key leakage
     - Sanitizes sensitive data in response bodies (API keys, billing data)
-    - Uses 'once' record mode by default (record once, then replay)
+    - Replays only by default; recording is opt-in via VENICE_VCR_RECORD
+      (``all`` to re-record, ``new`` to fill gaps). Cassettes are gitignored,
+      so a recording mode on a fresh clone spends real credit.
     - Stores cassettes in tests/cassettes/ directory
 
     CI Mode: When VENICE_CI_MODE=true, uses NONE mode to prevent recording.
@@ -990,21 +994,10 @@ def vcr_config():
         venice_ai.test_support.vcr_utilities - Comprehensive VCR documentation,
         usage guide, and compatibility notes for production code patterns.
     """
-    # Check if running in CI mode - never record cassettes in CI
-    ci_mode = os.getenv("VENICE_CI_MODE", "false").lower() == "true"
-    # VENICE_VCR_RECORD=all forces a full re-record of every interaction the
-    # selected tests touch, overwriting existing cassettes (record_on_exception
-    # below still prevents a failed call from clobbering a good cassette). This
-    # is the batching mechanism for refreshing cassettes: run any subset of
-    # tests with VENICE_VCR_RECORD=all to refresh exactly those, with no manual
-    # cassette deletion. CI mode always wins and never records.
-    force_record = os.getenv("VENICE_VCR_RECORD", "").lower() == "all"
-    if ci_mode:
-        record_mode = RecordMode.NONE
-    elif force_record:
-        record_mode = RecordMode.ALL
-    else:
-        record_mode = RecordMode.NEW_EPISODES
+    # Resolved centrally so this fixture and the benchmark suite's module-level
+    # VCR instance can never disagree about whether a run may touch the network.
+    # See tests/vcr_policy.py for the token table.
+    record_mode = resolve_record_mode()
 
     return vcr.VCR(
         cassette_library_dir="tests/integration/cassettes",
@@ -1063,11 +1056,7 @@ def vcr_cassette(vcr_config, request):
         return
 
     # Determine cassette directory based on test path
-    test_path = str(request.fspath)
-    if "tests/e2e/" in test_path:
-        cassette_dir = "tests/e2e/cassettes"
-    else:
-        cassette_dir = "tests/integration/cassettes"
+    cassette_dir = cassette_dir_for(str(request.fspath))
 
     # Configure the cassette library directory
     vcr_config.cassette_library_dir = cassette_dir
@@ -1166,11 +1155,7 @@ def vcr_error_cassette(vcr_config_with_errors, request):
         return
 
     # Determine cassette directory based on test path
-    test_path = str(request.fspath)
-    if "tests/e2e/" in test_path:
-        cassette_dir = "tests/e2e/cassettes"
-    else:
-        cassette_dir = "tests/integration/cassettes"
+    cassette_dir = cassette_dir_for(str(request.fspath))
 
     # Configure the cassette library directory
     vcr_config_with_errors.cassette_library_dir = cassette_dir

--- a/tests/integration/test_tee_live_schema.py
+++ b/tests/integration/test_tee_live_schema.py
@@ -13,7 +13,9 @@ import os
 import pytest
 
 from venice_ai import VeniceClient
+from venice_ai.exceptions import APIError
 from venice_ai.tee._evidence import detect_schema, normalize
+from venice_ai.tee.types import TeeAttestation
 
 pytest.importorskip("dcap_qvl")
 
@@ -26,17 +28,34 @@ pytestmark = [
 ]
 
 
-async def _first_e2ee_model(client: VeniceClient) -> str | None:
+async def _live_attestation(client: VeniceClient) -> TeeAttestation:
+    """Fetch an attestation from the first e2ee-* node that serves one.
+
+    An individual TEE node can be unreachable (502) while attestation as a
+    whole is healthy, and which node sits first in the model list is not this
+    test's concern — the wire schema is. So a 5xx moves on to the next
+    candidate; every other failure, a malformed attestation included,
+    propagates.
+    """
     models = await client.models.list(type="text")
-    return next((m.id for m in models.data if m.id.startswith("e2ee-")), None)
+    candidates = [m.id for m in models.data if m.id.startswith("e2ee-")]
+    if not candidates:
+        pytest.skip("no e2ee-* model entitled on this account")
+
+    unavailable: list[str] = []
+    for model in candidates:
+        try:
+            return await client.tee.get_attestation(model=model)
+        except APIError as exc:
+            if exc.status_code is None or exc.status_code < 500:
+                raise
+            unavailable.append(f"{model} ({exc.status_code})")
+    pytest.skip(f"no e2ee-* node served an attestation: {', '.join(unavailable)}")
 
 
 async def test_live_attestation_schema_is_recognized() -> None:
     async with VeniceClient() as client:
-        model = await _first_e2ee_model(client)
-        if model is None:
-            pytest.skip("no e2ee-* model entitled on this account")
-        attestation = await client.tee.get_attestation(model=model)
+        attestation = await _live_attestation(client)
 
         # Fails loudly if Venice changes the wire again.
         schema = detect_schema(attestation)
@@ -50,10 +69,7 @@ async def test_live_attestation_fully_verifies() -> None:
     from venice_ai.tee import DcapTdxVerifier
 
     async with VeniceClient() as client:
-        model = await _first_e2ee_model(client)
-        if model is None:
-            pytest.skip("no e2ee-* model entitled on this account")
-        attestation = await client.tee.get_attestation(model=model)
+        attestation = await _live_attestation(client)
 
         verifier = await DcapTdxVerifier.with_fetched_collateral(attestation.intel_quote)
         assert verifier.verify(attestation) is True

--- a/tests/unit/core/backends/test_redis_coverage.py
+++ b/tests/unit/core/backends/test_redis_coverage.py
@@ -48,7 +48,6 @@ class TestClusterModeConnection:
             mock_get_loop.return_value = mock_loop
 
             with (
-                patch("builtins.id", return_value=12345),
                 patch("venice_ai.core.backends.redis.RedisCluster") as mock_cluster,
             ):
                 mock_cluster_instance = AsyncMock()
@@ -83,7 +82,6 @@ class TestClusterModeConnection:
             mock_get_loop.return_value = mock_loop
 
             with (
-                patch("builtins.id", return_value=99999),  # New loop ID
                 patch("venice_ai.core.backends.redis.Redis") as mock_redis,
                 patch("venice_ai.core.backends.redis.ConnectionPool") as mock_pool_class,
             ):
@@ -122,7 +120,6 @@ class TestPingTimeoutHandling:
             mock_get_loop.return_value = mock_loop
 
             with (
-                patch("builtins.id", return_value=12345),
                 patch("venice_ai.core.backends.redis.Redis") as mock_redis_class,
                 patch("venice_ai.core.backends.redis.ConnectionPool") as mock_pool_class,
             ):
@@ -199,7 +196,6 @@ class TestRuntimeErrorHandling:
             mock_get_loop.return_value = mock_loop
 
             with (
-                patch("builtins.id", return_value=12345),
                 patch.object(RedisBackend, "_connection_pools", {}),
                 patch("venice_ai.core.backends.redis.ConnectionPool") as mock_pool_class,
             ):
@@ -221,7 +217,6 @@ class TestRuntimeErrorHandling:
             mock_get_loop.return_value = mock_loop
 
             with (
-                patch("builtins.id", return_value=12345),
                 patch.object(RedisBackend, "_connection_pools", {}),
                 patch("venice_ai.core.backends.redis.ConnectionPool") as mock_pool_class,
             ):
@@ -1058,37 +1053,36 @@ class TestEventLoopSwitchingBranches:
             mock_loop = MagicMock()
             mock_get_loop.return_value = mock_loop
 
-            with patch("builtins.id", return_value=22222):  # New loop ID
-                # Use a real create_task but track it
-                original_create_task = asyncio.create_task
+            # Use a real create_task but track it
+            original_create_task = asyncio.create_task
 
-                def tracking_create_task(coro, **kwargs):
-                    task = original_create_task(coro, **kwargs)
-                    created_tasks.append(task)
-                    return task
+            def tracking_create_task(coro, **kwargs):
+                task = original_create_task(coro, **kwargs)
+                created_tasks.append(task)
+                return task
 
-                with (
-                    patch("asyncio.create_task", side_effect=tracking_create_task),
-                    patch("venice_ai.core.backends.redis.Redis") as mock_redis,
-                    patch("venice_ai.core.backends.redis.ConnectionPool") as mock_pool_class,
-                ):
-                    mock_pool = MagicMock()
-                    mock_pool_class.from_url.return_value = mock_pool
+            with (
+                patch("asyncio.create_task", side_effect=tracking_create_task),
+                patch("venice_ai.core.backends.redis.Redis") as mock_redis,
+                patch("venice_ai.core.backends.redis.ConnectionPool") as mock_pool_class,
+            ):
+                mock_pool = MagicMock()
+                mock_pool_class.from_url.return_value = mock_pool
 
-                    new_redis = AsyncMock()
-                    new_redis.ping = AsyncMock(return_value=True)
-                    mock_redis.return_value = new_redis
+                new_redis = AsyncMock()
+                new_redis.ping = AsyncMock(return_value=True)
+                mock_redis.return_value = new_redis
 
-                    await backend._ensure_connected()
+                await backend._ensure_connected()
 
-                    # Verify cleanup task was created for old connection
-                    # (covers lines 125-131)
-                    assert len(created_tasks) >= 1
+                # Verify cleanup task was created for old connection
+                # (covers lines 125-131)
+                assert len(created_tasks) >= 1
 
-                    # Wait for cleanup tasks to complete
-                    for task in created_tasks:
-                        with contextlib.suppress(asyncio.TimeoutError, asyncio.CancelledError):
-                            await asyncio.wait_for(task, timeout=1.0)
+                # Wait for cleanup tasks to complete
+                for task in created_tasks:
+                    with contextlib.suppress(asyncio.TimeoutError, asyncio.CancelledError):
+                        await asyncio.wait_for(task, timeout=1.0)
 
 
 class TestPartialBranchCoverage:
@@ -1107,7 +1101,6 @@ class TestPartialBranchCoverage:
             mock_get_loop.return_value = mock_loop
 
             with (
-                patch("builtins.id", return_value=12345),
                 patch.object(RedisBackend, "_connection_pools", {}),
                 patch("venice_ai.core.backends.redis.ConnectionPool") as mock_pool_class,
             ):
@@ -1140,7 +1133,6 @@ class TestPartialBranchCoverage:
             mock_get_loop.return_value = mock_loop
 
             with (
-                patch("builtins.id", return_value=12345),
                 patch("venice_ai.core.backends.redis.Redis") as mock_redis_class,
                 patch("venice_ai.core.backends.redis.ConnectionPool") as mock_pool_class,
             ):

--- a/tests/unit/core/backends/test_redis_error_scenarios.py
+++ b/tests/unit/core/backends/test_redis_error_scenarios.py
@@ -25,11 +25,10 @@ class TestRedisBackendConnectionPoolManagement:
         # Mock the first event loop
         with patch("asyncio.get_running_loop") as mock_get_loop:
             mock_loop1 = MagicMock()
-            mock_loop1_id = 12345
+            mock_loop1_id = id(mock_loop1)
             mock_get_loop.return_value = mock_loop1
 
             with (
-                patch("builtins.id", return_value=mock_loop1_id),
                 patch("venice_ai.core.backends.redis.Redis") as mock_redis_class,
                 patch("venice_ai.core.backends.redis.ConnectionPool") as mock_pool_class,
             ):
@@ -49,13 +48,12 @@ class TestRedisBackendConnectionPoolManagement:
 
                 # Simulate event loop change
                 mock_loop2 = MagicMock()
-                mock_loop2_id = 67890
+                mock_loop2_id = id(mock_loop2)
                 mock_get_loop.return_value = mock_loop2
 
-                with patch("builtins.id", return_value=mock_loop2_id):
-                    # This should trigger the event loop change branch (lines 148-154)
-                    await backend._ensure_connected()
-                    assert backend._event_loop_id == mock_loop2_id
+                # This should trigger the event loop change branch (lines 148-154)
+                await backend._ensure_connected()
+                assert backend._event_loop_id == mock_loop2_id
 
     @pytest.mark.asyncio
     async def test_fallback_redis_connection_creation(self):
@@ -67,7 +65,6 @@ class TestRedisBackendConnectionPoolManagement:
             mock_get_loop.return_value = mock_loop
 
             with (
-                patch("builtins.id", return_value=12345),
                 patch("venice_ai.core.backends.redis.ConnectionPool", None),
                 patch("venice_ai.core.backends.redis.Redis", None),
                 patch("venice_ai.core.backends.redis.redis") as mock_redis_module,
@@ -93,14 +90,13 @@ class TestRedisBackendConnectionPoolManagement:
         mock_existing_redis.ping = AsyncMock(side_effect=ConnectionError("Connection lost"))
         backend._redis = mock_existing_redis
         backend._connected = True
-        backend._event_loop_id = 12345
 
         with patch("asyncio.get_running_loop") as mock_get_loop:
             mock_loop = MagicMock()
             mock_get_loop.return_value = mock_loop
+            backend._event_loop_id = id(mock_loop)  # Same loop: no pool switch
 
             with (
-                patch("builtins.id", return_value=12345),  # Same loop ID
                 patch("venice_ai.core.backends.redis.Redis") as mock_redis_class,
                 patch("venice_ai.core.backends.redis.ConnectionPool") as mock_pool_class,
             ):

--- a/tests/unit/test_vcr_policy.py
+++ b/tests/unit/test_vcr_policy.py
@@ -1,0 +1,137 @@
+"""Guards on the VCR record-mode policy.
+
+Recording is not a neutral default: a cassette-less request under any recording
+mode reaches the live Venice API and bills the key holder. Cassettes are
+gitignored, so a fresh clone has none. These tests pin the policy that keeps a
+plain ``make test`` from spending money, and pin the two VCR call sites to a
+single source of truth so one can never replay while the other dials out.
+"""
+
+import pytest
+from vcr.record_mode import RecordMode
+
+from tests.vcr_policy import (
+    CI_ENV_VAR,
+    DEFAULT_CASSETTE_DIR,
+    RECORD_ENV_VAR,
+    cassette_dir_for,
+    resolve_record_mode,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_vcr_env(monkeypatch):
+    """Each case states its own environment; inherit nothing from the shell."""
+    monkeypatch.delenv(RECORD_ENV_VAR, raising=False)
+    monkeypatch.delenv(CI_ENV_VAR, raising=False)
+
+
+def test_default_never_records() -> None:
+    """The unconfigured local default must not be able to reach the network."""
+    assert resolve_record_mode() is RecordMode.NONE
+
+
+@pytest.mark.parametrize(
+    ("setting", "expected"),
+    [
+        ("all", RecordMode.ALL),
+        ("ALL", RecordMode.ALL),
+        ("new", RecordMode.NEW_EPISODES),
+        ("", RecordMode.NONE),
+        ("yes", RecordMode.NONE),
+        ("true", RecordMode.NONE),
+    ],
+)
+def test_recording_is_opt_in_by_exact_token(monkeypatch, setting, expected) -> None:
+    """Only the documented tokens record; anything else stays offline.
+
+    A truthy-looking value like ``true`` must NOT enable recording — guessing
+    wrong here costs real money.
+    """
+    monkeypatch.setenv(RECORD_ENV_VAR, setting)
+    assert resolve_record_mode() is expected
+
+
+def test_ci_mode_overrides_an_explicit_record_request(monkeypatch) -> None:
+    monkeypatch.setenv(CI_ENV_VAR, "true")
+    monkeypatch.setenv(RECORD_ENV_VAR, "all")
+    assert resolve_record_mode() is RecordMode.NONE
+
+
+def test_root_fixture_uses_the_shared_policy(monkeypatch) -> None:
+    """The root ``vcr_config`` fixture must not hardcode its own mode."""
+    from tests.conftest import vcr_config
+
+    built = vcr_config.__wrapped__()
+    assert built.record_mode is RecordMode.NONE
+
+
+def test_benchmark_module_uses_the_shared_policy() -> None:
+    """Regression guard: the benchmark module used to hardcode ``RecordMode.ONCE``.
+
+    That module-level instance shadows the fixture name, so ``VENICE_CI_MODE``
+    did not reach it and it recorded — and therefore billed — whenever a
+    cassette was absent, including under a run explicitly asking for CI mode.
+    """
+    from tests.benchmarks import test_vcr_scheduler_benchmarks as bench
+
+    assert bench.vcr_config.record_mode is resolve_record_mode()
+    assert bench.vcr_config.record_mode is not RecordMode.ONCE
+
+
+def test_default_mode_blocks_an_unrecorded_request(tmp_path) -> None:
+    """The default must REFUSE an unrecorded request, not forward it.
+
+    This is the property that actually protects the credit card: under the old
+    NEW_EPISODES default, a request with no cassette entry was sent to the live
+    API and appended. Here the request is aimed at a closed local port, so a
+    pass-through would surface as a connection error. Seeing VCR's own
+    "can't overwrite" exception instead proves the request never left the
+    process.
+    """
+    import vcr as vcr_module
+    from vcr.errors import CannotOverwriteExistingCassetteException
+
+    recorder = vcr_module.VCR(
+        cassette_library_dir=str(tmp_path),
+        record_mode=resolve_record_mode(),
+    )
+
+    import urllib.error
+    import urllib.request
+
+    with (
+        recorder.use_cassette("absent.yaml"),
+        pytest.raises(CannotOverwriteExistingCassetteException),
+    ):
+        urllib.request.urlopen("http://127.0.0.1:1/never", timeout=1)  # noqa: S310
+
+    assert not list(tmp_path.iterdir()), "a blocked run must not write a cassette"
+
+
+@pytest.mark.parametrize(
+    ("test_path", "expected"),
+    [
+        ("/repo/tests/e2e/test_live.py", "tests/e2e/cassettes"),
+        (
+            "/repo/tests/benchmarks/test_vcr_scheduler_benchmarks.py",
+            "tests/benchmarks/vcr_cassettes",
+        ),
+        ("/repo/tests/integration/test_chat.py", DEFAULT_CASSETTE_DIR),
+        ("/repo/tests/unit/test_thing.py", DEFAULT_CASSETTE_DIR),
+    ],
+)
+def test_cassette_dir_routing(test_path, expected) -> None:
+    assert cassette_dir_for(test_path) == expected
+
+
+def test_benchmarks_do_not_fall_through_to_integration() -> None:
+    """Regression guard for the miss that sent every benchmark request live.
+
+    Benchmark cassettes live in tests/benchmarks/vcr_cassettes, but the fixture
+    only special-cased e2e, so benchmarks resolved to the integration directory
+    and no cassette could ever match.
+    """
+    resolved = cassette_dir_for("/repo/tests/benchmarks/test_vcr_scheduler_benchmarks.py")
+    assert resolved != DEFAULT_CASSETTE_DIR
+    assert resolved == "tests/benchmarks/vcr_cassettes"

--- a/tests/vcr_policy.py
+++ b/tests/vcr_policy.py
@@ -1,0 +1,74 @@
+"""Single source of truth for VCR record-mode policy.
+
+Every VCR call site in the suite resolves its record mode here. Two call sites
+previously decided independently — the root ``vcr_config`` fixture and a
+module-level ``vcr.VCR`` in the benchmark suite — which meant a single run could
+have one path replaying from cassettes while the other silently dialled out to
+the live API.
+
+Recording is not a neutral default. Cassettes are gitignored, so a fresh clone
+has none, and under any recording mode a cassette-less request goes to the real
+Venice API and bills whoever's ``VENICE_API_KEY`` is set. Recording is therefore
+opt-in, by exact token.
+"""
+
+from __future__ import annotations
+
+import os
+
+from vcr.record_mode import RecordMode
+
+#: Opts a local run in to recording. Unset means "replay only, never record".
+RECORD_ENV_VAR = "VENICE_VCR_RECORD"
+
+#: Set by CI. Always wins, and always means "never record".
+CI_ENV_VAR = "VENICE_CI_MODE"
+
+#: ``VENICE_VCR_RECORD`` value -> mode. Membership is exact: a truthy-looking
+#: value that isn't listed here leaves the run offline rather than guessing that
+#: the caller meant to spend money.
+_RECORD_MODES = {
+    "all": RecordMode.ALL,
+    "new": RecordMode.NEW_EPISODES,
+}
+
+
+def resolve_record_mode() -> RecordMode:
+    """Return the VCR record mode for this run.
+
+    ==========================  ===================  ==========================
+    ``VENICE_VCR_RECORD``       Mode                 Behaviour
+    ==========================  ===================  ==========================
+    unset (default)             ``NONE``             replay only; a request with
+                                                     no cassette raises
+    ``all``                     ``ALL``              re-record every interaction
+                                                     the selected tests touch
+    ``new``                     ``NEW_EPISODES``     replay, record only gaps
+    ==========================  ===================  ==========================
+
+    ``VENICE_CI_MODE=true`` forces ``NONE`` regardless of the above.
+    """
+    if os.getenv(CI_ENV_VAR, "false").lower() == "true":
+        return RecordMode.NONE
+    return _RECORD_MODES.get(os.getenv(RECORD_ENV_VAR, "").lower(), RecordMode.NONE)
+
+
+#: Test-path fragment -> cassette directory. Ordered most-specific first.
+_CASSETTE_DIRS = (
+    ("tests/e2e/", "tests/e2e/cassettes"),
+    # Benchmarks keep cassettes beside themselves; without an entry here they
+    # fall through to the integration directory, where no cassette can match and
+    # every request either goes live or fails outright.
+    ("tests/benchmarks/", "tests/benchmarks/vcr_cassettes"),
+)
+
+#: Where a test lands when no fragment matches.
+DEFAULT_CASSETTE_DIR = "tests/integration/cassettes"
+
+
+def cassette_dir_for(test_path: str) -> str:
+    """Return the cassette directory serving the test at ``test_path``."""
+    for fragment, directory in _CASSETTE_DIRS:
+        if fragment in test_path:
+            return directory
+    return DEFAULT_CASSETTE_DIR


### PR DESCRIPTION
The VCR policy was the entry point: recording was on by default, so every local run replayed against the live API and spent credit. Recording is now opt-in via `VENICE_VCR_RECORD`, the generated benchmark report is ignored rather than committed, and the saturation benchmark creates its report directory instead of failing on the write.

Fixing that surfaced everything else. The saturation benchmark was configured with a `redis_url` but no `backend_type`, so it had been silently exercising the in-process backend the whole time. Pointing it at Redis is what made the next findings visible.

## `adaptive-rate-limiter` floor raised to `>=1.3.0`

Two independent layers had to change before the limiter could adapt to this API at all.

Reset stamps arrive as absolute epoch **milliseconds**; the library rewrote its own clean integer through `str(float(...))`, failed to parse the result, substituted `0`, and had its Lua reject the update on a post-2020 sanity floor. That was fixed in 1.2.1.

Above it sat a gate that wasn't. `_assess_header_availability` scored all six `x-ratelimit-*` headers as one pool and demanded all six before syncing anything. Venice sends three — it meters requests, not tokens — so every response fell through to release-only: the backend was never called, the bucket was never verified, and the limiter ran on fabricated cold-start limits for the life of the process. It failed silently, since the release path returns success and logs at debug. Measured against a live model: **427 cold-start probes across 66 minutes with the bucket never once written.** 1.3.0 assesses the gate per dimension, so a request-only provider syncs the dimension it reports.

`1.2.x` is excluded deliberately rather than incidentally: 1.2.0 clamps an out-of-range token window, which rotates it early and refills the token count before the server does, and 1.2.1 still cannot clear the header gate here.

Verified against the released wheel rather than the rc — gate returns `full` on real headers, all four Lua sentinel probes match the rc row for row, and a live run writes the bucket on response 1 with `vrf_req=1` alongside `vrf_tok=0`, the pairing that distinguishes a correctly skipped dimension from an unwritten bucket.

## Two tests that passed for the wrong reason

**`patch("builtins.id")` corrupted coverage's tracer.** The sysmon core registers each code object exactly once as `code_infos[id(code)]` and returns `DISABLE`, while LINE/BRANCH events stay bound to the real code object. Any object first seen inside a patched block was filed under a fake key, so every later lookup raised `KeyError` from inside `coverage/sysmon.py` — surfacing in whatever test happened to be running, usually one that never patched `id` itself. It took down **55 tests**, and only under load, since registration and lookup have to straddle the patch. Loop identity is expressed directly now: `id(mock_loop)` for "same loop", a non-matching value for "switched". Each test's own assertion still gates the branch it was written to cover.

This is invisible in CI, which is why it shipped in v2.0.0: coverage only defaults to sysmon on Python **3.14+**, and every workflow pins 3.13.

**The live TEE check depended on one node's health.** Attestation is served per model node, and one can be down while the rest are fine — `e2ee-gemma-3-27b-p` returned 502 on every attempt while `e2ee-gemma-4-26b-a4b-uncensored-p` served a valid 10 KB quote seconds later. Taking the first `e2ee-*` model in list order made the test a coin flip rather than a check of the wire schema it exists to guard. It walks the candidates now, passing over **5xx only** — a malformed attestation still propagates, so genuine schema drift is not masked.

## Verification

Full suite green locally. The limiter upgrade is not verifiable by the saturation benchmark, which passed on 1.1.0 with the feedback path completely dead; the discriminators are the Lua return code and the `vrf_req` / `vrf_tok` provenance flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)