### PR TITLE
chore(make): install extras in `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,9 +84,14 @@ help: ## Show this help message
 # =====================================================
 # INSTALLATION
 # =====================================================
+# --all-extras is required, not optional, and matches the validate job in CI.
+# Without it the TEE, x402 and Solana test modules skip wholesale (importorskip
+# on cryptography, dcap-qvl, eth-account, siwe, solders) and mypy degrades the
+# same imports to Any — a green local run that never exercised the most
+# security-sensitive code in the SDK.
 install: ## Install all dependencies
 	@echo "$(GREEN)Installing dependencies...$(NC)"
-	$(POETRY) install --with dev
+	$(POETRY) install --with dev --all-extras
 
 # =====================================================
 # TESTING TARGETS

--- a/README.md
+++ b/README.md
@@ -601,7 +601,7 @@ See [Installation Options](#installation-options) for optional dependencies.
 
 ```bash
 git clone https://github.com/sethbang/venice-py.git && cd venice-py
-poetry install
+make install
 make test
 ```
 


### PR DESCRIPTION
`make install` ran `poetry install --with dev` — no extras. That doesn't match CI's validate job (`ci-validation.yaml:66`), which installs `--with dev --all-extras`, and the mismatch is a quiet one.

Without extras, the TEE, x402 and Solana test modules `importorskip` on `cryptography`, `dcap-qvl`, `eth-account`, `siwe` and `solders`, so they **skip wholesale rather than fail**, and mypy degrades the same imports to `Any`. A local run comes back green having never exercised the most security-sensitive code in the SDK — which is exactly the reasoning already written above the CI install step.

The gap is easy to hit without noticing, because plain `poetry install` never removes anything: an environment set up once with extras keeps working indefinitely, until a `poetry sync` prunes it back to the default selection and takes 31 packages with it.

## Changes

- `Makefile` — `poetry install --with dev` → `poetry install --with dev --all-extras`, with the rationale recorded above the target.
- `README.md` — the Contributing snippet said `poetry install` then `make test`; it now says `make install`, so there's one command to keep correct instead of two.

`CONTRIBUTING.md` already said `poetry install --all-extras` and needed no change (the `dev` group is non-optional, so it installs by default).

## Verification

`make -n install` expands to `poetry install --with dev --all-extras`. Running it against an environment installed with those exact flags is a clean no-op ("No dependencies to install or update"), and all previously-missing optional imports resolve: `redis`, `siwe`, `eth_account`, `dcap_qvl`, `solders`, `cryptography`, `pydantic_settings`, `opentelemetry.trace`.

No dependency or lockfile changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)