### PR TITLE
release: 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - 2026-09-01
+
 ### Changed
 
 - **`abnf` is now capped at `<2.9`** on the `x402` extra. `siwe` accepts `abnf >=2.2,<3`,
@@ -801,7 +803,8 @@ _Initial public release. No retroactive release notes documented._
 
 **Note**: This changelog follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. For detailed technical information about any changes, please refer to the git commit history or the linked source files.
 
-[Unreleased]: https://github.com/sethbang/venice-py/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/sethbang/venice-py/compare/v2.2.1...HEAD
+[2.2.1]: https://github.com/sethbang/venice-py/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/sethbang/venice-py/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/sethbang/venice-py/compare/v2.0.2...v2.1.0
 [2.0.2]: https://github.com/sethbang/venice-py/compare/v2.0.1...v2.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "venice-py"
-version = "2.2.0"
+version = "2.2.1"
 description = "Unofficial, community-maintained Python SDK for Venice.ai, offering comprehensive access to the API with unified architecture and intelligent rate limiting."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Cuts the `[Unreleased]` section as **2.2.1**. Both fixes it carries are live defects in the *published* 2.2.0 — verified against the PyPI wheel, not inferred from the source:

```
venice-py 2.2.0 from PyPI + pydantic 2.13.5
  content[0] -> dict
  .text -> AttributeError: 'dict' object has no attribute 'text'

venice-py[x402]==2.2.0  ->  abnf resolved to 2.9.0
  import siwe -> GrammarError: 'ALPHA' is a core rule from RFC 5234 appendix B...
```

2.2.0 shipped `pydantic = "^2.13.4"`, which resolves to 2.13.5, and carried no `abnf` cap at all. So every fresh install hits the first, and every install of the `x402` extra hits the second — an import-time hard failure that takes out the whole SIWE/x402 auth path. Neither is fixable downstream without pinning transitives by hand.

**Patch rather than minor:** bug fixes and dependency constraints only, with no additions, removals or signature changes to the public API.

## Changes

- `pyproject.toml` — `version = "2.2.0"` → `"2.2.1"`
- `CHANGELOG.md` — `[Unreleased]` retitled `## [2.2.1] - 2026-09-01`, fresh empty `[Unreleased]` opened above it, link refs repointed

No source literal to update: `__version__` resolves from package metadata via `_pkg_version("venice-py")`.

## Verification

Built the artifact and tested it against both live breakages:

```
venice-py 2.2.1 | __version__ 2.2.1 | pydantic 2.13.5
  content[0] -> TextContent | .text -> hi

venice-py[x402] 2.2.1 | abnf 2.8.3 | siwe 4.4.0
  import siwe -> OK
```

The second confirms the `abnf <2.9` cap reached the **wheel metadata**, so a fresh `pip install venice-py[x402]` resolves 2.8.3 rather than the 2.9.0 that breaks the import.

Also ran `release.yaml`'s `version-check` shell logic verbatim against tag `v2.2.1` → `OK — versions match`.

## `venice-ai` bridge — no action needed

The old-name shim lives outside this repo, so nothing here touches it. Its published metadata floors rather than pins:

```
Requires-Dist: venice-py>=2.2.0
```

So `pip install venice-ai` picks up 2.2.1 automatically once this publishes. No second release required.

## Publishing

After merge, **create a GitHub Release tagged `v2.2.1`**. `release.yaml` fires on `release: [published]`, not on tag push — the tag arrives with the release, so don't push one by hand. Its `version-check` job compares `pyproject.toml` against the tag and refuses to publish on mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)