### PR TITLE
fix: accept mapping venice_parameters in chat.completions type hints (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`venice_parameters=` now type-checks with a plain dict.** Both `chat.completions.create()` overloads annotated the parameter `VeniceParameters | None`, which is narrower than what the code accepts: a mapping of the same fields has always been validated and coerced by `ChatCompletionRequest`, but type checkers rejected the call — and because `create()` is overloaded, the diagnostic reported the whole call as unmatched (`No overload variant of "create" ... matches argument types`) without naming the offending argument. The annotation is now `VeniceParameters | Mapping[str, Any] | None`. `ChatCompletionRequest.venice_parameters` deliberately stays model-only; it is the validation boundary where mappings are coerced. Note that `VeniceParameters` is `extra="allow"`, so an unrecognized key is carried through rather than rejected — identically for either form. Reported alongside the `messages=` variant in [#1](https://github.com/sethbang/venice-py/issues/1), tracked as [#58](https://github.com/sethbang/venice-py/issues/58).
+
 ## [2.2.1] - 2026-09-01
 
 ### Changed

--- a/src/venice_ai/resources/chat/completions.py
+++ b/src/venice_ai/resources/chat/completions.py
@@ -71,7 +71,7 @@ import asyncio
 import inspect
 import logging
 import warnings
-from collections.abc import AsyncIterable, AsyncIterator, Callable, Sequence
+from collections.abc import AsyncIterable, AsyncIterator, Callable, Mapping, Sequence
 from decimal import Decimal
 from typing import (
     TYPE_CHECKING,
@@ -497,7 +497,7 @@ class ChatCompletions(APIResource["VeniceClient"]):
         tools: Sequence[Tool] | None = None,
         tool_choice: Literal["none", "auto"] | SpecificToolChoice | None = None,
         user: str | None = None,  # Discarded but supported for OpenAI compat
-        venice_parameters: VeniceParameters | None = None,
+        venice_parameters: VeniceParameters | Mapping[str, Any] | None = None,
         # --- Venice-Specific Params ---
         reasoning_effort: ReasoningEffortLevel | None = None,
         reasoning: ReasoningConfig | None = None,
@@ -549,7 +549,7 @@ class ChatCompletions(APIResource["VeniceClient"]):
         tools: Sequence[Tool] | None = None,
         tool_choice: Literal["none", "auto"] | SpecificToolChoice | None = None,
         user: str | None = None,
-        venice_parameters: VeniceParameters | None = None,
+        venice_parameters: VeniceParameters | Mapping[str, Any] | None = None,
         # --- Venice-Specific Params ---
         reasoning_effort: ReasoningEffortLevel | None = None,
         reasoning: ReasoningConfig | None = None,
@@ -659,7 +659,13 @@ class ChatCompletions(APIResource["VeniceClient"]):
             user: Unique identifier representing your end-user (discarded
                 by API but supported for OpenAI compatibility).
             venice_parameters: Venice-specific parameters for fine-tuning
-                model behavior.
+                model behavior. Accepts a :class:`VeniceParameters` or a
+                plain mapping of the same fields; a mapping is validated
+                into the model while the request body is built, so an
+                invalid value still raises before the request is sent.
+                Note that :class:`VeniceParameters` is ``extra="allow"``,
+                so an unrecognized key is carried through rather than
+                rejected — the same for either form.
             reasoning_effort: Controls thinking depth on reasoning models.
                 One of ``"none"``, ``"minimal"``, ``"low"``, ``"medium"``,
                 ``"high"``, ``"xhigh"``, or ``"max"``. Takes precedence

--- a/tests/unit/resources/test_chat_venice_parameters_mapping.py
+++ b/tests/unit/resources/test_chat_venice_parameters_mapping.py
@@ -1,0 +1,170 @@
+"""Unit tests for plain-mapping ``venice_parameters`` input on chat.completions.
+
+``venice_parameters=`` accepts either a :class:`VeniceParameters` or a plain
+mapping of the same fields. The mapping is validated into the model while
+``ChatCompletionRequest`` is built, so the two forms are interchangeable and an
+invalid value still raises before the request is sent.
+
+Unlike ``messages=``, nothing reads ``venice_parameters`` attributes ahead of the
+request model, so this is a typing fix rather than a behavior change — these
+tests exist to pin the equivalence the annotation now advertises.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import ValidationError
+
+from venice_ai.resources.chat.completions import ChatCompletions, _e2ee_engaged
+from venice_ai.types.api import ChatCompletionRequest
+from venice_ai.types.api.requests.common import VeniceParameters
+
+_FAKE_CHAT_MODEL = "fake-chat-test-model"
+
+_MESSAGES = [{"role": "user", "content": "hi"}]
+
+
+class _MockClient:
+    def __init__(self):
+        self.post = AsyncMock(
+            return_value={
+                "id": "resp-1",
+                "object": "chat.completion",
+                "created": 1000000,
+                "model": _FAKE_CHAT_MODEL,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# ChatCompletionRequest — the validation boundary
+# ---------------------------------------------------------------------------
+
+
+class TestRequestModelCoercesMapping:
+    def test_mapping_becomes_the_model(self):
+        request = ChatCompletionRequest(
+            model=_FAKE_CHAT_MODEL,
+            messages=list(_MESSAGES),
+            venice_parameters={"enable_web_search": "on"},
+        )
+
+        assert isinstance(request.venice_parameters, VeniceParameters)
+        assert request.venice_parameters.enable_web_search == "on"
+
+    def test_mapping_and_model_are_equivalent(self):
+        from_mapping = ChatCompletionRequest(
+            model=_FAKE_CHAT_MODEL,
+            messages=list(_MESSAGES),
+            venice_parameters={"enable_web_search": "on"},
+        )
+        from_model = ChatCompletionRequest(
+            model=_FAKE_CHAT_MODEL,
+            messages=list(_MESSAGES),
+            venice_parameters=VeniceParameters(enable_web_search="on"),
+        )
+
+        assert from_mapping.model_dump() == from_model.model_dump()
+
+    def test_unrecognized_key_is_carried_through_for_both_forms(self):
+        # VeniceParameters is extra="allow", so a key the model doesn't declare
+        # survives coercion rather than being dropped or rejected. Pinned here
+        # because it is the opposite of how the *message* models behave
+        # (extra="ignore"), and the two are easy to conflate.
+        from_mapping = ChatCompletionRequest(
+            model=_FAKE_CHAT_MODEL,
+            messages=list(_MESSAGES),
+            venice_parameters={"some_future_flag": True},
+        )
+        from_model = ChatCompletionRequest(
+            model=_FAKE_CHAT_MODEL,
+            messages=list(_MESSAGES),
+            venice_parameters=VeniceParameters(some_future_flag=True),
+        )
+
+        assert from_mapping.model_dump() == from_model.model_dump()
+        assert from_mapping.model_dump()["venice_parameters"]["some_future_flag"] is True
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            {"enable_web_search": "nope"},
+            {"enable_web_search": 123},
+            {"enable_web_citations": "notabool"},
+        ],
+    )
+    def test_invalid_value_still_raises(self, bad):
+        with pytest.raises(ValidationError):
+            ChatCompletionRequest(
+                model=_FAKE_CHAT_MODEL,
+                messages=list(_MESSAGES),
+                venice_parameters=bad,
+            )
+
+
+# ---------------------------------------------------------------------------
+# create()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestCreateAcceptsMapping:
+    async def test_mapping_and_model_produce_identical_body(self):
+        from_mapping = _MockClient()
+        await ChatCompletions(from_mapping).create(
+            model=_FAKE_CHAT_MODEL,
+            messages=list(_MESSAGES),
+            venice_parameters={"enable_web_search": "on"},
+        )
+
+        from_model = _MockClient()
+        await ChatCompletions(from_model).create(
+            model=_FAKE_CHAT_MODEL,
+            messages=list(_MESSAGES),
+            venice_parameters=VeniceParameters(enable_web_search="on"),
+        )
+
+        assert from_mapping.post.call_args == from_model.post.call_args
+
+    async def test_invalid_mapping_raises_before_the_request(self):
+        client = _MockClient()
+        with pytest.raises(ValidationError):
+            await ChatCompletions(client).create(
+                model=_FAKE_CHAT_MODEL,
+                messages=list(_MESSAGES),
+                venice_parameters={"enable_web_search": "nope"},
+            )
+        client.post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# E2EE engagement
+# ---------------------------------------------------------------------------
+
+
+class TestE2EEDetectionSeesMapping:
+    """``_e2ee_engaged`` inspects the caller's raw value, before coercion.
+
+    A mapping must engage the encrypted flow exactly as the model does —
+    otherwise ``venice_parameters={"enable_e2ee": True}`` would silently send
+    plaintext.
+    """
+
+    def test_mapping_engages(self):
+        assert _e2ee_engaged(False, {"enable_e2ee": True}) is True
+
+    def test_model_engages(self):
+        assert _e2ee_engaged(False, VeniceParameters(enable_e2ee=True)) is True
+
+    def test_mapping_without_the_flag_does_not_engage(self):
+        assert _e2ee_engaged(False, {"enable_web_search": "on"}) is False
+
+    def test_none_does_not_engage(self):
+        assert _e2ee_engaged(False, None) is False


### PR DESCRIPTION
Closes #58.

## The problem

Both `chat.completions.create()` overloads annotated `venice_parameters: VeniceParameters | None`, which is narrower than what the code accepts. A mapping of the same fields has always been validated and coerced by `ChatCompletionRequest`, but type checkers rejected the call:

```
error: No overload variant of "create" of "ChatCompletions" matches argument
types "str", "list[dict[str, str]]", "dict[str, str]"  [call-overload]
```

Because `create()` is overloaded, the diagnostic doesn't name the offending argument — it reports the whole call as unmatched, which is harder to act on than the `messages=` version was.

Reported in #1 alongside the `messages=` variant. That half shipped in 2.0.1; this one didn't.

## The fix

- `Mapping` added to the `collections.abc` import — it wasn't there.
- Both `create()` overloads widened to `VeniceParameters | Mapping[str, Any] | None`.
- The `venice_parameters:` docstring extended, including the `extra="allow"` note.

`ChatCompletionRequest.venice_parameters` **deliberately stays model-only** — same boundary decision as `messages=`: that field is where coercion happens.

**Annotation-only.** Unlike `messages=`, nothing reads `venice_parameters` attributes before the request model — it is popped from kwargs and passed straight through — so no runtime normalization was needed. `resources/responses.py` already annotates it `Any | None` and was never affected.

## Verification

Every unit test here would have passed *before* this change, since runtime always accepted dicts. They pin the equivalence the annotation now advertises; the type-checker probe is what actually discriminates, so it was run in both directions:

| probe | before | after |
|---|---|---|
| `venice_parameters={"enable_web_search": "on"}` | `[call-overload]` | `Success` |
| `venice_parameters=VeniceParameters(...)` | `Success` | `Success` |
| `venice_parameters=42` | error | **still errors** |

The last row is the one that matters — widening to `Mapping[str, Any]` must not quietly turn the hint into `Any`.

- `mypy src/` — clean, 172 source files
- `ruff check` + `ruff format --check` — clean
- 12 new tests in `tests/unit/resources/test_chat_venice_parameters_mapping.py`: request-model coercion, body equivalence through `create()`, `extra="allow"` parity between the two forms, invalid values still raising before any request, and E2EE engagement via a mapping (`venice_parameters={"enable_e2ee": True}` must engage the encrypted flow, or it would silently send plaintext)
- `tests/unit/resources/` — 736 passed

`make test` not run — that one's yours.

Accepting strictly more than before, so this is non-breaking → patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
