### PR TITLE
chore(deps): patch qs to 6.16.0 and stop Dependabot reopening abnf 2.9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,16 @@ updates:
       - "sethbang"
     assignees:
       - "sethbang"
+    ignore:
+      # abnf 2.9.0 made redefining an RFC 5234 core rule a hard error, and siwe's
+      # own rfc5234 grammar redefines ALPHA, so 2.9.x breaks `import siwe`
+      # outright. siwe 4.4.0 is the latest release and still ships that grammar,
+      # so there is nothing to upgrade to. pyproject pins abnf <2.9 for this
+      # reason; without this ignore, Dependabot reopens the same failing PR
+      # every week. Drop both once siwe stops redefining core rules.
+      - dependency-name: "abnf"
+        versions: [">=2.9"]
+
     # Group minor and patch updates together
     groups:
       production-dependencies:

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -16344,12 +16344,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"

--- a/website/package.json
+++ b/website/package.json
@@ -38,6 +38,7 @@
   "overrides": {
     "serialize-javascript": "^7.0.5",
     "minimatch@9.0.3": "9.0.9",
+    "qs@6.15.2": "6.16.0",
     "yaml@2.8.1": "2.9.0",
     "uuid@8.3.2": "11.1.1"
   },


### PR DESCRIPTION
Two recurring red runs in Actions, neither caused by a code change. Both are dependency-resolution problems.

## 1. `qs` — Dependabot security update fails weekly

Not a test failure: the *updater* gives up with `security_update_not_possible` and never opens a PR (3 occurrences: 2026-09-03 ×2, 2026-09-07).

GHSA-4mjr-xmp4-gh2g and GHSA-x5fp-wj9c-mxmx (both medium) are fixed in `qs` 6.16.0, but `express@4.22.2` and `body-parser@1.20.6` both declare `qs: "~6.15.1"` (`>=6.15.1 <6.16.0`), so nothing resolves to the fix.

**Reachability.** `qs` reaches us only via `@docusaurus/core → webpack-dev-server@5.2.6 → express` — the local `npm start` dev server. The static build deployed to Pages never runs it. But it is *not* unreachable: express (`lib/middleware/query.js`, `lib/utils.js`) and body-parser (`lib/types/urlencoded.js`) both pass `allowPrototypes: true`, which is exactly the precondition for the isBuffer DoS. So this pins the fix rather than dismissing the alerts.

**The override is deliberate and out-of-range.** `"qs@6.15.2": "6.16.0"` overrides the `~6.15.1` range express declares. It is keyed on `pkg@version` so it retargets only that one resolution instead of collapsing every `qs` in the tree — same pattern as the existing `minimatch`/`yaml`/`uuid` entries.

Verified:
- `npm run build` succeeds (82 documents, llms.txt generated)
- dev server starts and serves; query parser exercised with plain, bracket-comma (`a[]=1,2,3,4`) and prototype-shaped query strings, server stays up
- lockfile diff touches `qs` only
- `npm audit` 21 → 18; the 3 removed are exactly the qs moderates. The remaining 18 highs are pre-existing on `main` (`image-size` via `@docusaurus/mdx-loader`) and are out of scope here.

## 2. `abnf` — Dependabot reopens a PR that cannot pass

#62 bumps `abnf` 2.8.3 → 2.9.0 and widens the `pyproject.toml` pin from `<2.9` to `<2.10`. CI fails with 1 failure + 12 collection errors:

```
abnf._parser_python.GrammarError: 'ALPHA' is a core rule from RFC 5234 appendix B,
shared by every grammar, so a grammar cannot define it
```

abnf 2.9.0 made redefining an RFC 5234 core rule a hard error; `siwe/grammars/rfc5234.py:14` still contains `ALPHA = %x41-5A / %x61-7A`, so 2.9.x breaks `import siwe` outright. **siwe 4.4.0 is the latest release on PyPI and still ships that grammar**, so bumping siwe is not an option — the pin has to stay.

The `pyproject.toml` comment already documents this; the missing piece was a Dependabot `ignore`, without which the same failing PR reopens every Monday.

Closing #62 alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)